### PR TITLE
Use Redis cache to keep track of currently connected users

### DIFF
--- a/api/RedisForWishList.py
+++ b/api/RedisForWishList.py
@@ -1,0 +1,47 @@
+# Class to handle the Redis cache connection and operations for the WishList
+import json
+
+from core.models import WishListUser
+from django.core.cache import cache
+
+
+class RedisForWishList:
+    """Cache backend was set to use the default redis cache alias"""
+
+    def __init__(self):
+        self.timeout = 60 * 60 * 24  # 24 hours
+
+    def get_currently_connected_users(self, room_group_name: str, current_user: WishListUser) -> list:
+        """
+        Get the list of currently connected users in the group via Redis
+        Save the user in the group if it is not already in it
+        Usernames are unique, so no need to check for duplicates
+        """
+        if not cache.get(room_group_name):
+            # If the room does not exist, we create it and add the user
+            room_connected_users = [current_user.name]
+            cache.set(room_group_name, json.dumps(room_connected_users), timeout=self.timeout)
+        else:
+            # If the room exists, we add the user to the list when it is not already in it
+            room_connected_users = json.loads(cache.get(room_group_name))
+            if current_user.name not in room_connected_users:
+                room_connected_users.append(current_user.name)
+                cache.set(room_group_name, json.dumps(room_connected_users), timeout=self.timeout)
+
+        return room_connected_users
+
+    def remove_user_from_connected_users(self, room_group_name: str, current_user: WishListUser) -> list:
+        """Remove the user from the connected users in the group"""
+        room_connected_users = []
+        if cache.get(room_group_name):
+            # Get the list of connected users and remove the current user
+            room_connected_users = json.loads(cache.get(room_group_name))
+            room_connected_users.remove(current_user.name)
+            if not room_connected_users:
+                # If the room is empty, we delete it
+                cache.delete(room_group_name)
+            else:
+                # If the room is not empty, we update the list of connected users
+                cache.set(room_group_name, json.dumps(room_connected_users), timeout=self.timeout)
+
+        return room_connected_users

--- a/api/routing.py
+++ b/api/routing.py
@@ -3,6 +3,5 @@ from django.urls import path
 from . import consumers
 
 websocket_urlpatterns = [
-    # path("ws/wishlist/<uuid:wishlist_id>/", consumers.WishlistConsumer.as_asgi()),
     path("ws/wishlist/<uuid:wishlist_user>/", consumers.WishlistConsumer.as_asgi()),
 ]

--- a/api/tests/test_consumers.py
+++ b/api/tests/test_consumers.py
@@ -4,13 +4,20 @@ from uuid import UUID
 from asgiref.sync import sync_to_async
 from channels.routing import URLRouter
 from channels.testing import WebsocketCommunicator
-from django.test import TransactionTestCase
+from django.test import TransactionTestCase, override_settings
 
 from api.routing import websocket_urlpatterns
 from api.tests.factories import WishListFactory, WishListUserFactory, WishFactory
 from core.models import Wish
 
 
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
+    }
+)
 class WishlistConsumerTest(TransactionTestCase):
     def setUp(self):
         super().setUp()

--- a/api/tests/test_redis_for_wishlist.py
+++ b/api/tests/test_redis_for_wishlist.py
@@ -1,0 +1,79 @@
+# REDIS CACHE TESTS
+import json
+
+from django.core.cache import cache
+
+from api.RedisForWishList import RedisForWishList
+from api.tests.utils import SimpleWishlistBaseTestCase
+
+
+class TestRedisForWishList(SimpleWishlistBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.redis_for_wishlist = RedisForWishList()
+        cache.clear()
+
+    def tearDown(self):
+        # super().tearDown()
+        cache.clear()
+
+    def test_room_does_not_exist_creates_room_and_adds_user(self):
+        """Test that the WishlistConsumer creates the room and adds the user to it if it does not exist."""
+        cache.clear()
+        current_user = self.user
+        room_group_name = "test_room"
+
+        result = self.redis_for_wishlist.get_currently_connected_users(room_group_name, current_user)
+
+        self.assertEqual(result, [self.user.name])
+
+        # Check that the cache variable was set
+        self.assertEqual(json.loads(cache.get(room_group_name)), [self.user.name])
+
+    def test_room_exists_adds_user(self):
+        """Test that the WishlistConsumer adds the user to the room if it is not already in it."""
+        # A user is already in the room, so the consumer should add the second user
+        current_user = self.second_user
+        room_group_name = "test_room"
+        cache.set("test_room", json.dumps([self.user.name]))
+
+        result = self.redis_for_wishlist.get_currently_connected_users(room_group_name, current_user)
+
+        self.assertEqual(result, [self.user.name, self.second_user.name])
+        self.assertEqual(json.loads(cache.get(room_group_name)), [self.user.name, self.second_user.name])
+
+    def test_room_exists_user_already_in_the_room(self):
+        """Test that the WishlistConsumer does not add the user to the room if it is already in it."""
+        cache.set("test_room", json.dumps([self.user.name]))
+        current_user = self.user
+        room_group_name = "test_room"
+
+        result = self.redis_for_wishlist.get_currently_connected_users(room_group_name, current_user)
+
+        self.assertEqual(result, [self.user.name])
+        self.assertEqual(json.loads(cache.get(room_group_name)), [self.user.name])
+
+    def test_remove_user_from_room(self):
+        """Test that the WishlistConsumer removes the user from the room."""
+        cache.set("test_room", json.dumps([self.user.name]))
+        current_user = self.user
+        room_group_name = "test_room"
+
+        result = self.redis_for_wishlist.remove_user_from_connected_users(room_group_name, current_user)
+
+        self.assertEqual(result, [])
+        self.assertIsNone(cache.get(room_group_name))
+
+    def test_remove_user_but_keep_cache_if_other_users(self):
+        """
+        Test that the WishlistConsumer removes the user from the room but keeps the cache variable
+        if other users are still connected.
+        """
+        cache.set("test_room", json.dumps([self.user.name, self.second_user.name]))
+        current_user = self.user
+        room_group_name = "test_room"
+
+        result = self.redis_for_wishlist.remove_user_from_connected_users(room_group_name, current_user)
+
+        self.assertEqual(result, [self.second_user.name])
+        self.assertEqual(json.loads(cache.get(room_group_name)), [self.second_user.name])

--- a/core/fixtures/wishlist_data.json
+++ b/core/fixtures/wishlist_data.json
@@ -468,7 +468,7 @@
       "url": "https://www.amazon.com/Book/dp/B00G6Z3Z1Q",
       "description": "Preferably a book about dragons.",
       "wishlist_user": "021963b3-d4a2-4901-a99c-50799a304908",
-      "assigned_user": null
+      "assigned_user": "6999920a-67df-4c0d-8299-ebc88446d64c"
     }
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,6 +17,7 @@ distlib==0.3.8
 django==5.0.6
 django-cors-headers==4.4.0
 django-ninja==1.1.0
+django-redis==5.4.0
 factory-boy==3.3.0
 faker==26.0.0
 filelock==3.15.4

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -22,6 +22,7 @@ distlib==0.3.8
 django==5.0.6
 django-cors-headers==4.4.0
 django-ninja==1.1.0
+django-redis==5.4.0
 factory-boy==3.3.0
 faker==26.0.0
 filelock==3.15.4

--- a/simplewishlist/settings/base.py
+++ b/simplewishlist/settings/base.py
@@ -84,6 +84,18 @@ CHANNEL_LAYERS = {
     },
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": f"redis://{os.environ["REDIS_HOST"]}:{os.environ["REDIS_PORT"]}/0",  # Database 1
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 


### PR DESCRIPTION
 Caches Content with Redis: Any data you store in Django's cache framework (e.g., cache.set()) will be saved in Redis, which is fast and memory-efficient.

Stores Sessions in Redis: Session are now stored in the Redis cache, speeding up session reads and writes.

Use this new configuration to store the data about connected users, allowing to access the connected users not matter the worker used. 