### PR TITLE
Config for reverse proxy in prod

### DIFF
--- a/simplewishlist/settings/prod.py
+++ b/simplewishlist/settings/prod.py
@@ -9,3 +9,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
+
+USE_X_FORWARDED_HOST = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")


### PR DESCRIPTION
Allow request.build_absolute_uri to return https. 